### PR TITLE
Code for rendering templates in a different way & sending email/tweet for new event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
-AmsterdamX.pm
-=============
+# AmsterdamX.pm
 
-AmsterdamX.pm community website
-
-TODO: template needs to account for title, meta-description per page
+## For adding a new event:
+1 Add it in templates/new_event.yaml, having fields :
+  * month
+  * day (monday, tuesday...)
+  * daynum (day of the month, e.g. 10th, 11th...)
+  * room
+  * floor
+  * survey_link
+  * talks
+    * talk1
+      * speaker
+      * title
+      * detail
+        * line1 of detail
+        * line2 of detail..
+2 Move text under "Upcoming events" to "Previous events", in templates/events.haml
+3 Remove "Upcoming events" from templates/events.haml
+4 Create a configuration file having path ~/amsterdamx_conf.yaml
+5 Add these fields for email and tweet in ~/amsterdamx_conf.yaml:
+  * host
+  * port
+  * username
+  * password (if not in the conf file, you will be prompted for it later on)
+  * to (comma separated list for sending multiple addresses)
+  * from
+  * consumer_key
+  * consumer_secret
+  * access_token
+  * access_token_secret
+5 make

--- a/bin/create.sh
+++ b/bin/create.sh
@@ -21,9 +21,10 @@ fi
 
 pushd templates
 
-"$base"/bin/render_events.pl events.haml > events.tt
+"$base"/bin/render_events.pl
+"$base"/bin/send_email_and_tweets.pl "$HOME"/amsterdamx_conf.yaml
 
-pages_list="about events index"
+pages_list="about events"
 
 for page in $pages_list; do
     echo "Creating $page..."

--- a/bin/render_events.pl
+++ b/bin/render_events.pl
@@ -3,20 +3,97 @@
 use strict;
 use warnings;
 
-use IO::All;
+use feature qw(say);
+
+use Data::Dumper;
 use Text::Haml;
+use IO::All;
 
-my ($filename) = @ARGV
-    or die "$0 <file.html>\n";
+use Template;
 
-my $haml     = Text::Haml->new;
-my $template = io($filename)->slurp;
-my $output   = $haml->render($template);
+use YAML qw(LoadFile);
 
-print << "_END";
+my $event_ref = LoadFile('new_event.yaml');
+
+my %event     = %$event_ref;
+
+my $month     = $event_ref->{ month };
+my $daynum    = $event_ref->{ daynum };
+my $year      = $event_ref->{ year };
+my $space     = "  ";
+
+my $text =<<END;
+%h2 Upcoming Events
+%div
+  %h3 $month $daynum, $year
+  %ol
+END
+
+my $talks_string;
+for my $key ( keys %{$event_ref->{ talks }} ) {
+    my $talk    = $event_ref->{ talks }->{ $key };
+    my $talk_detail;
+    my $speaker;
+    my $title;
+    if( $talk ) {
+        $speaker    = $talk->{ speaker };
+        $title      = $talk->{ title };
+        my $detail  = $talk->{ detail };
+        if( ref $detail ) {
+            my @detail  = @{$talk->{ detail }};
+
+            for( my $j = 0; $j <= $#detail; $j++ ) {
+                my $line = $detail[ $j ];
+                $talk_detail .= "      %p $line";
+                if( $j != $#detail ) {
+                    $talk_detail .= "\n";
+                }
+            }
+        } else {
+                $talk_detail .= "      %p $detail\n";
+        }
+    } else {
+        last;
+    }
+
+    my $this_talk =<<END;
+    %li
+      %h4
+        %span $speaker
+        :: $title
+$talk_detail
+END
+
+    $talks_string .= $this_talk;
+}
+
+$text .= $talks_string;
+
+my $events_haml = io('events.haml')->slurp();
+$events_haml = $text.$events_haml;
+io('events.haml')->write( $events_haml );
+
+my $haml = Text::Haml->new( encoding => '');
+my $events = $haml->render_file('events.haml');
+
+my $text_for_events_tt =<<END;
 [% WRAPPER root.tt %]
     <h1>Events</h1>
-$output
+$events
 [% END %]
-_END
+END
 
+io('events.tt')->write( $text_for_events_tt );
+
+my $template_name;
+my $rendered_text;
+
+## Render index.tt
+
+my $tt = Template->new ();
+
+$template_name = "index.tt";
+
+$tt->process( $template_name,
+              $event_ref,
+              '../generated/index.html' ) || die $tt->error()."\n";

--- a/bin/send_email_and_tweets.pl
+++ b/bin/send_email_and_tweets.pl
@@ -1,0 +1,148 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use feature qw(say);
+
+use Template;
+
+use Email::Simple;
+use Email::Sender::Simple 'sendmail';
+use Email::Sender::Transport::SMTP;
+
+use Net::Twitter;
+
+use YAML qw(LoadFile);
+
+use Data::Dumper;
+
+use LWP::UserAgent;
+use HTTP::Request;
+
+use JSON;
+
+my $conf_file;
+if( $#ARGV >= 0 ) {
+    $conf_file = $ARGV[ 0 ];
+} else {
+    die "Usage : perl send_email_and_tweets.pl <conf_file_name>\n";
+}
+
+# Read event details
+my $event_ref = LoadFile('new_event.yaml');
+my $month = $event_ref->{ month };
+my $daynum = $event_ref->{ daynum };
+
+# Sending email code
+
+# Read email configuration from a YAML file
+my $conf     = LoadFile($conf_file);
+my $username = $conf->{ username };
+my $password = $conf->{ password };
+if( !$password ) {
+    print "Please enter password for the email: ";
+    $password = <STDIN>;
+    chomp $password;
+}
+my $host     = $conf->{ host };
+my $to       = $conf->{ to };
+my $from     = $conf->{ from };
+my $port     = $conf->{ port };
+
+# sending email part
+
+my $email_body;
+my $subject;
+my $template_name;
+
+while( 1 ) {
+    print "What kind of email you would like to send?\n";
+    print "1 Announcement\n";
+    print "2 Reminder\n";
+    print "3 Teaser\n";
+    my $option = <STDIN>;
+    chomp $option;
+
+    if( $option == 1 ) {
+        $template_name = "announcement.tt";
+        $subject    = "Amsterdam eXpats Perl Mongers $month meeting ($month $daynum, 18:30)";
+        last;
+    } elsif( $option == 2 ) {
+        $template_name = "reminder.tt";
+        $subject    = "[REMINDER] $month $daynum: AmsterdamX.pm";
+        last;
+    } elsif( $option == 3 ) {
+        $template_name = "teaser.tt";
+        $subject    = "";
+        last;
+    } else {
+        print "Invalid optipn\n";
+    }
+}
+
+my $tt = Template->new();
+$tt->process( "email_templates/".$template_name, $event_ref, \$email_body ) or die $tt->error();
+
+my $transport = Email::Sender::Transport::SMTP->new({
+    host          => $host,
+    port          => $port,
+    ssl           => 1,
+    sasl_username => $username,
+    sasl_password => $password,
+    debug         => 1
+});
+
+my $email = Email::Simple->create(
+    header => [
+        To      => $to,
+        From    => $from,
+        Subject => $subject,
+    ],
+    body    => $email_body,
+);
+sendmail($email, { transport => $transport });
+
+## Code for sending tweet
+
+print "Do you wanna send a tweet as well? (y/n)";
+my $yes_or_no = <STDIN>;
+chomp $yes_or_no;
+if( $yes_or_no =~ /(n|N)/ ) {
+    exit 0;
+} elsif( $yes_or_no =~ /(y|Y)/ ) {
+    my $consumer_key = $conf->{ consumer_key };
+    my $consumer_secret = $conf->{ consumer_secret };
+    my $access_token = $conf->{ access_token };
+    my $access_token_secret = $conf->{ access_token_secret };
+
+    my $nt = Net::Twitter->new(
+        traits => ['API::RESTv1_1'],
+        consumer_key => $consumer_key,
+        consumer_secret => $consumer_secret,
+        access_token => $access_token,
+        access_token_secret => $access_token_secret,
+        );
+
+    my $url = get_shorten_url();
+    my $result = $nt->update("Next AmsterdamX.pm meetup has been announced, check out more details here : $url. See you there! :)");
+}
+
+sub get_shorten_url {
+    my $uri = 'https://www.googleapis.com/urlshortener/v1/url';
+    my $json = to_json({ longUrl => "http://amsterdamx.pm.org/#new_event" });
+    my $req = HTTP::Request->new( 'POST', $uri );
+    $req->header( 'Content-Type' => 'application/json' );
+    $req->content( $json );
+
+    my $lwp = LWP::UserAgent->new;
+    my $response = $lwp->request( $req );
+
+    if ($response->is_success) {
+        my $result = from_json( $response->decoded_content );
+        return $result->{ id };
+    }
+    else {
+        die $response->status_line;
+    }
+}

--- a/templates/email_templates/announcement.tt
+++ b/templates/email_templates/announcement.tt
@@ -1,0 +1,50 @@
+This [% month %] we're getting lots of amazing speakers. Don't miss it!
+
+Please also fill in the following form if you intend to come:
+$survey
+
+In a nutshell:
+Date: [% daynum %], [% month %] [% day %].
+Time: 18:30 - 20:30 (theoretically)
+Location: Booking.com, Herengracht 597, [% room %] room on [% floor %] floor.
+
+Talks:
+[% FOREACH key IN talks.keys %]
+[% talks.$key.speaker %] - [% talks.$key.title %]
+[% FOREACH line IN talks.$key.detail %]
+[% line %]
+[% END %]
+[% END %]
+Unabridged:
+You've probably heard of the Perl Mongers meetings, where fellow Perl (and non-Perl) programmers can get together to "talk shop", make fun of everything (including Perl), and have a good time. These meetings often have a few technical talks (which are usually light-hearted, and not necessarily - but likely - involve Perl). There are already Amsterdam.pm meetings. This is not about those. This is about AmsterdamX.pm.
+
+The talks can be a 5 minute tidbit about a cool module, or a 40 minute tutorial about some cool new (or old) software.
+
+AmsterdamX.pm?
+AmsterdamX.pm (Amsterdam eXpats Perl Mongers) is a new Perl Mongers group whose purpose is to optimize for expats. The major differences are:
+* use English; We might speak more than 50 languages, but we commonly speak only one.
+* Meeting early: we meet at 18:30, so you can come straight from work instead of having a long buffer time to the meeting.
+* Held at Booking.com, where most Perl expats in Amsterdam already work.
+
+This isn't to replace Amsterdam.pm, but to provide an additional group. It is only meant to supplement.
+
+Why should I attend?
+Here are a few reasons which might appeal to you:
+* You will improve your knowledge of Perl (and most likely other technologies) through the knowledge and experience of others. It's like a free course, with snacks!
+* You could give a talk and share your knowledge and experience. If you're going to YAPC to give a talk, this is great practice.
+* It's a wonderful chance to socialize.
+
+How many talks, and how long are they?
+Usually there will be 2-3 talks, ranging between 5 minutes (lightning) and 40 minutes (tutorial).
+
+Is it just for Booking.com?
+No. This isn't Booking.pm, this is AmsterdamX.pm. (also, Sparta!)
+This means that everyone is invited! We suggest that people register so we could have a good estimate of the people arriving. This will help with various things like optimized snack distribution, making sure reception knows of people arriving that don't have keys, making sure we get a proper room, etc.
+
+Now I'm interested, what's the next step?
+Please let us know by return email if you will be attending as well as the names of anyone you plan on bringing from outside of Booking.com.
+
+Then mark the date, time and place, and show up!
+
+See you there!
+

--- a/templates/email_templates/reminder.tt
+++ b/templates/email_templates/reminder.tt
@@ -1,0 +1,13 @@
+Hey everyone,
+
+It's time for the official reminder that TOMORROW there's an
+AmsterdamX.pm meeting with some very awesome people:
+[% FOREACH key IN talks.keys %]
+* [% talks.$key.speaker %] - [% talks.$key.title %]
+[% END %]
+
+Date: [% daynum %], [% month %] [% day %].
+Time: 18:30 - 20:30 (theoretically).
+Location: Booking.com, Herengracht 597, [% room %] Room on [% floor %] floor.
+
+Remember to fill in the survey: [% survey %].

--- a/templates/events.haml
+++ b/templates/events.haml
@@ -1,30 +1,5 @@
-%h2 Upcoming Events
+%h2 Previous Events
 %div
-  %h3 November 25th, 2014
-  %ol
-    %li
-      %h4
-        %span H.Merijn Brand (tux)
-        :: What I miss in "pack" and "unpack"
-      %p Pack and unpack enable us to view binary data as structured data. Using advanced patterns, these data chunks might even be perceived as dynamic data sources. There is one drawback on the implementation of unpack in the CORE: it only works on scalar values.
-      %p I will not show you how it can be done (that will be quite an job), but I will try to show you how code could change if unpack were to work on data streams as well. I'll use PerlMonk posts as examples, though my original idea came from something I'll also show.
-      %p I hope this will be some kind of interactive, and there will be a discussion on weather this is a useful feature to implement. It will not be a slick slideshow.
-    %li
-      %h4
-        %span Damien Krotkine (dams)
-        :: Exceptions with no strings attached
-      %p Perl exceptions can be anything, as long as they are scalars. This bring issues. Exception::Stringy aims to fix that
-    %li
-      %h4
-        %span Peter Rabbitson (ribasushi)
-        :: DBIx::Class - what is it and what is it good for?
-      %p DBIx::Class is a widely used and just as widely misunderstood SQL metaprogramming framework (no, it is not an ORM, it just plays one on TV).
-      %p Come to see the primary maintainer of DBIx::Class (a.k.a. DBIC) give an overview of its architecture, show some more advanced use cases where the library really shines, and generally rant about the sorry state of the RDBMS universe. ;)
-    %li
-      %h4
-        %span Stevan Little
-        :: Plack::Debugger: A new debugger for Plack Applications
-      %p Plack::Debugger is a newly released addition to the Plack toolbox. It is a rethinking of the excellent Plack::Middleware::Debug module designed specifically to work with the AJAX heavy web applications of today. This talk will provide an overview of the straight-out-of-the-box functionality this module provides, as well as examples of how to extend it for your particular environment.
   %h3 September 30th, 2014
   %ol
     %li
@@ -80,9 +55,6 @@
         :: MetaCPAN::API is dead!
       %p MetaCPAN::Client provides the official interface to MetaCPAN's abundance of features and introspection.
       %p Reading the documentation is boring, come to my talk instead!
-
-%h2 Previous Events
-%div
   %h3 January 28th, 2014
   %ol
     %li
@@ -96,4 +68,3 @@
         :: Perl and the Web - A Love Story
       %p In the beginning of the great kingdom of the Internet, there was one ruler: Perl. With time, fallen from grace, the beautiful princess language lost its place on the throne, giving way to Ruby, Python, and to the dismay and horror of everyone in the kingdom, PHP.
       %p But all is not lost. While underground, Perl has schemed a plot to overthrow the competitors. That plan is Plack/PSGI.
-

--- a/templates/index.tt
+++ b/templates/index.tt
@@ -1,6 +1,42 @@
-[% WRAPPER root.tt %]
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>AmsterdamX.pm (Perl Mongers group)</title>
+    <meta name="description" content="Community of English speaking Perl developers in Amsterdam.">
+    <meta name="keywords" content="perl,amsterdam,amsterdam.pm,amsterdamx.pm">
+<!-- events needs different title, description...
+    <title>Events - AmsterdamX.pm</title>
+    <meta name="description" content="Upcoming and previous events and meetings of the AmsterdamX Perl Mongers group.">
+    <meta name="keywords" content="events,meetings,perl,amsterdam,amsterdam.pm,amsterdamx.pm"> -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" media="screen, projection, handheld" href="css.css">
+    <!--[if lte IE 8]>
+      <script>
+        var list='footer,main,nav'.split(','),
+            el;
+        while(el=list.pop()){
+            document.createElement(el);
+        }
+      </script>
+    <![endif]-->
+    <!-- still need: under IE9 stylesheet, print stylesheet -->
+  </head>
+  <body>
+    <nav role="navigation">
+        <ul>
+  <li><a href="/">Home</a></li>
+  <li><a href="events.html">Events</a></li>
+  <li><a href="#footer">About</a></li>
+</ul>
+
+    </nav>
+    <div class="container">
+      <main role="main">
+
         <div>
-          <h1>AmsterdamX.pm</h1> 
+          <h1>AmsterdamX.pm</h1>
           <p>AmsterdamX is a <a href="http://www.pm.org">Perl Mongers</a> group of English-speaking Perl developers in Amsterdam. We meet to have talks and/or social time every so often, usually monthly.</p>
           <p><a href="#footer">Read more about who we are</a>.</p>
         </div>
@@ -12,51 +48,47 @@
             <p class="upcoming"><a href="events.html#upcoming">Upcoming events</a></p><!-- perl events too like FOSDEM?-->
         </div>
         <div>
-            <h2>Next Scheduled Event</h2>
+            <a id="new_event" href="#new_event"><h2>Next Scheduled Event</h2></a>
             <dl>
               <dt>Date:</dt>
-              <dd>Tuesday, November 25th.</dd>
+              <dd>[% daynum %], [% month %] [% day %].</dd>
               <dt>Time:</dt>
               <dd>18.30&#8211;20.30 (approximately)</dd>
               <dt>Location:</dt>
-              <dd><a href="https://www.google.com/maps/preview#!q=Herengracht+597%2C+1017CE+Grachtengordel-Zuid%2C+Amsterdam%2C+The+Netherlands&data=!4m11!1m10!2i23!4m8!1m3!1d23194967!2d-95.677068!3d37.0625!3m2!1i1228!2i683!4f13.1">Booking.com, 1017CE, Herengracht 597 (Google Map)</a>, Bejing Room.</dd>
-              <dd>Please fill in <a href="https://www.surveymonkey.com/s/5CVZS3K">this form</a> if you're arriving.</dd>
+              <dd><a href="https://www.google.com/maps/preview#!q=Herengracht+597%2C+1017CE+Grachtengordel-Zuid%2C+Amsterdam%2C+The+Netherlands&data=!4m11!1m10!2i23!4m8!1m3!1d23194967!2d-95.677068!3d37.0625!3m2!1i1228!2i683!4f13.1">Booking.com, 1017CE, Herengracht 597 (Google Map)</a>, [% room %] Room, [% floor %] floor.</dd>
+              <dd>Please fill in <a href="[% survey_link %]">this form</a> if you're arriving.</dd>
               <dt>Talks:</dt>
               <dd>
-                <ol>
-                    <li>
-                      <h4>
-                        <span>H.Merijn Brand (tux)</span>
-                        :: What I miss in &quot;pack&quot; and &quot;unpack&quot;
-                      </h4>
-                      <p>Pack and unpack enable us to view binary data as structured data. Using advanced patterns, these data chunks might even be perceived as dynamic data sources. There is one drawback on the implementation of unpack in the CORE: it only works on scalar values.</p>
-                      <p>I will not show you how it can be done (that will be quite an job), but I will try to show you how code could change if unpack were to work on data streams as well. I&apos;ll use PerlMonk posts as examples, though my original idea came from something I&apos;ll also show.</p>
-                      <p>I hope this will be some kind of interactive, and there will be a discussion on weather this is a useful feature to implement. It will not be a slick slideshow.</p>
-                    </li>
-                    <li>
-                      <h4>
-                        <span>Damien Krotkine (dams)</span>
-                        :: Exceptions with no strings attached
-                      </h4>
-                      <p>Perl exceptions can be anything, as long as they are scalars. This bring issues. Exception::Stringy aims to fix that</p>
-                    </li>
-                    <li>
-                      <h4>
-                        <span>Peter Rabbitson (ribasushi)</span>
-                        :: DBIx::Class - what is it and what is it good for?
-                      </h4>
-                      <p>DBIx::Class is a widely used and just as widely misunderstood SQL metaprogramming framework (no, it is not an ORM, it just plays one on TV).</p>
-                      <p>Come to see the primary maintainer of DBIx::Class (a.k.a. DBIC) give an overview of its architecture, show some more advanced use cases where the library really shines, and generally rant about the sorry state of the RDBMS universe. ;)</p>
-                    </li>
-                    <li>
-                      <h4>
-                        <span>Stevan Little</span>
-                        :: Plack::Debugger: A new debugger for Plack Applications
-                      </h4>
-                      <p>Plack::Debugger is a newly released addition to the Plack toolbox. It is a rethinking of the excellent Plack::Middleware::Debug module designed specifically to work with the AJAX heavy web applications of today. This talk will provide an overview of the straight-out-of-the-box functionality this module provides, as well as examples of how to extend it for your particular environment.</p>
-                    </li>
-                </ol>
-              </dd> 
+                [% FOREACH key IN talks.keys %]
+                    <ol>
+                      <li>
+                        <h4>
+                          <span>[% talks.$key.speaker %]</span>
+                          :: [% talks.$key.title %]
+                        </h4>
+                        [% FOREACH line IN talks.$key.detail %]
+                        <p>[% line %]</p>
+                        [% END %]
+                      </li>
+                    </ol>
+                [% END %]
+              </dd>
             </dl>
         </div>
-[% END %]
+
+      </main>
+      <div role="contentinfo" id="footer" tabindex="-1">
+        <h2>About AmsterdamX.pm</h2>
+  <p>AmsterdamX.pm (Amsterdam e<strong>X</strong>pats Perl Mongers) is a new Perl Mongers group whose purpose is to optimize for expats. The major differences from <a href="http://perl.nl/amsterdam/">Amsterdam.pm</a> are:</p>
+  <ul>
+    <li>use English; We might speak more than 50 languages, but we commonly speak only one.</li>
+    <li>Meeting early: we meet at 18:30, so you can come straight from work instead of having a long buffer time to the meeting.</li>
+    <li>Held at Booking.com (<a href="https://www.google.com/maps/preview#!q=Herengracht+597%2C+1017CE+Grachtengordel-Zuid%2C+Amsterdam%2C+The+Netherlands&data=!4m11!1m10!2i23!4m8!1m3!1d23194967!2d-95.677068!3d37.0625!3m2!1i1228!2i683!4f13.1">location</a>), where most Perl expats in Amsterdam already work.</li>
+  </ul>
+  <p>This isn't instead of Amsterdam.pm, but to provide an additional group. It is not meant to replace, but to supplement. There is no affiliation between Amsterdam.pm and AmsterdamX.pm.</p>
+
+      </div>
+    </div>
+    <script src="js.js"></script>
+  </body>
+</html>

--- a/templates/new_event.yaml
+++ b/templates/new_event.yaml
@@ -1,0 +1,36 @@
+month : November
+daynum : 25th
+day : Tuesday
+year : 2014
+room : Beijing
+floor : 5th
+survey : survey_link
+    
+talks :
+    talk1 :
+          speaker : H.Merijn Brand (tux)
+          title : What I miss in "pack" and "unpack"
+          detail :
+                 - "Pack and unpack enable us to view binary data as structured data. Using advanced patterns, these data chunks might even be perceived as dynamic data sources. There is one drawback on the implementation of unpack in the CORE: it only works on scalar values."
+                 - "I will not show you how it can be done (that will be quite an job), but I will try to show you how code could change if unpack were to work on data streams as well. I'll use PerlMonk posts as examples, though my original idea came from something I'll also show."
+                 - "I hope this will be some kind of interactive, and there will be a discussion on weather this is a useful feature to implement. It will not be a slick slideshow."
+
+    talk2 :
+          speaker : Damien Krotkine (dams)
+          title : Exceptions with no strings attached
+          detail :
+                 - "Perl exceptions can be anything, as long as they are scalars. This bring issues. Exception::Stringy aims to fix that"
+
+
+    talk3 :
+          speaker : Peter Rabbitson (ribasushi)
+          title : "DBIx::Class - what is it and what is it good for?"
+          detail :
+                 - "DBIx::Class is a widely used and just as widely misunderstood SQL metaprogramming framework (no, it is not an ORM, it just plays one on TV)."
+                 - "Come to see the primary maintainer of DBIx::Class (a.k.a. DBIC) give an overview of its architecture, show some more advanced use cases where the library really shines, and generally rant about the sorry state of the RDBMS universe. ;)"
+
+
+    talk4 :
+          speaker : Stevan Little
+          title : "Plack::Debugger: A new debugger for Plack Applications"
+          detail : "Plack::Debugger is a newly released addition to the Plack toolbox. It is a rethinking of the excellent Plack::Middleware::Debug module designed specifically to work with the AJAX heavy web applications of today. This talk will provide an overview of the straight-out-of-the-box functionality this module provides, as well as examples of how to extend it for your particular environment."


### PR DESCRIPTION
For sending emails, we need to have event details for filling in the email templates.
Now render_events.pl fetches event details from a YAML template, renders events.haml & index.tt.
Also added a new script for sending emails and tweet.
 