### PR TITLE
remove whitespace menu;add top id;hide page variable in order to read it

### DIFF
--- a/templates/menu.tt
+++ b/templates/menu.tt
@@ -1,6 +1,6 @@
 <ul>
-  <li><a[% page == 'home'   ? ' class="current"' : '' %] href="/">Home</a></li>
-  <li><a[% page == 'events' ? ' class="current"' : '' %] href="events.html">Events</a></li>
-  <li><a href="#footer">About</a></li>
-  <li><a href="https://www.youtube.com/channel/UCqVaoUlQ7PLQ0LA19p3HxTw">Videos</a></li>
-</ul>
+  <li><a[% page == 'home'   ? ' class="current"' : '' %] href="/">Home</a></li
+  ><li><a[% page == 'events' ? ' class="current"' : '' %] href="events.html">Events</a></li
+  ><li><a href="#footer">About</a></li
+  ><li><a href="https://www.youtube.com/channel/UCqVaoUlQ7PLQ0LA19p3HxTw">Videos</a></li
+></ul><span class="hidden">[% page %]</span>

--- a/templates/root.tt
+++ b/templates/root.tt
@@ -24,7 +24,7 @@
     <!-- still need: under IE9 stylesheet, print stylesheet -->
   </head>
   <body>
-    <nav role="navigation">
+    <nav role="navigation" id="top">
         [% INCLUDE menu.tt %]
     </nav>
     <div class="container">


### PR DESCRIPTION
Whitespace gone again brings back the all-browsers-are-1px-apart in menu.
ID of "top" should let the back-to-top smoothscroll back up.
The page variable is visually hidden and will be removed after I can see what I should add to "home" (unless someone already knows and wants to change it).